### PR TITLE
Verify root folder

### DIFF
--- a/makeitdark.py
+++ b/makeitdark.py
@@ -90,6 +90,9 @@ else:
     require_sudo = False
     for root in os.environ['LOCALAPPDATA'], os.environ['PROGRAMFILES']:
         slack_root_path = os.path.join(root, "slack")
+        if not os.path.exists(slack_root_path):  
+            print("Slack not found at {0}".format(slack_root_path))
+            continue
         slack_versions = sorted([slack_version for slack_version in os.listdir(slack_root_path) if
                                  slack_version.startswith("app-") and os.path.isdir(
                                      os.path.join(slack_root_path, slack_version))], reverse=True)


### PR DESCRIPTION
Check if the root path exists before looking for slack inside it thus avoiding an operating system exception from being thrown.